### PR TITLE
filter option to handle filtering in the app rather than in the library

### DIFF
--- a/gasrequire.js
+++ b/gasrequire.js
@@ -10,20 +10,24 @@ var debug = util.debuglog('gas-local:require');
  * 
  * @param {string} folderPath to folder with downloaded app scripts
  * @param {object} globalObject to pass to module. globalMock will be passed if not specified
+ * @param {object} options that give more control over behavour. options.filter can be to determine which files are loaded into the context
  * @returns module
  */
-function gasrequire(folderPath, globalObject) {
+function gasrequire(folderPath, globalObject, options) {
   if (!globalObject) {
     debug('no globalObject passed. use default mock');
     globalObject = require('./globalmock-default');
   }
 
-  debug('loading from folder: %s...', folderPath)
-  var files = fs.readdirSync(folderPath);
-  var gsFiles = files.filter(function (f) {
+  options = typeof options === 'object' ? options : {};
+  var filterFunc  = options.filter ? options.filter : function(f) {
     var ext = path.extname(f);
     return ext == '.js';
-  });
+  };
+
+  debug('loading from folder: %s...', folderPath)
+  var files = fs.readdirSync(folderPath);
+  var gsFiles = files.filter(filterFunc);
 
   var ctx = vm.createContext(globalObject);
 


### PR DESCRIPTION
I have a use case where I need to exclude some files from loading into the context. (It's a file that has to exist in the Google stack who has a function that mirrors a utility on the node side. If it's defined in the context (so that it exists on Google) that mirror function does not get executed.)

This way the programmer can just do: 

```js
let path = require('path');
let ctx = gas.require('./src', {}, {filter: function(f) {
    var ext = path.extname(f),
        base = path.basename(f);
    return ext == '.js' && basename != 'exclude';
});
```

And that way the calling application has more control over how it operates. Other options might in the future be used as well.